### PR TITLE
fix: guard schema migrations against orphaned runs_new and fix rowid ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.9.2 — 2026-04-10
+
+### Bug Fixes
+
+- **Schema migration safety**: Each `CREATE TABLE runs_new` migration block now drops any pre-existing `runs_new` table first. Without this guard, an interrupted migration (e.g. mid-restart) left an orphaned `runs_new` table that caused every subsequent startup to abort schema initialization, leaving the `runs` table missing columns (`kill_requested_at`, `extra_instructions`, `session_id`, `session_cwd`) and breaking all endpoints that touched those columns.
+
+- **`ORDER BY rowid` for linked databases**: `getRows()` in `database.ts` and `buildRunPayload()` in `runs.ts` both sorted linked agent-managed tables by `_id DESC`. Tables created before v1.9 use `id TEXT PRIMARY KEY` and have no `_id` column, causing a `SqliteError: no such column: _id` inside `buildRunPayload()`. Since `buildRunPayload()` is called after a run is already claimed (status set to `running`), the error caused the `/next` polling endpoint to return 500 while the run remained permanently stuck in `running`. Switching to `rowid` works for both old (`id TEXT`) and new (`_id INTEGER`) table generations.
+
 ## v1.9.0 — 2026-04-10
 
 ### Run Detail Actions

--- a/src/lib/db/database.ts
+++ b/src/lib/db/database.ts
@@ -234,7 +234,7 @@ export function getRows(databaseId: string, opts?: {
     const dir = opts?.order === "ASC" ? "ASC" : "DESC";
     sql += ` ORDER BY "${opts.orderBy}" ${dir}`;
   } else {
-    sql += ` ORDER BY _id DESC`;
+    sql += ` ORDER BY rowid DESC`;
   }
 
   sql += ` LIMIT ? OFFSET ?`;

--- a/src/lib/db/runs.ts
+++ b/src/lib/db/runs.ts
@@ -401,7 +401,7 @@ function buildRunPayload(runId: string) {
   const data: Record<string, any> = {};
   for (const d of linkedDbs) {
     data[d.name] = db.prepare(
-      `SELECT * FROM "${d.table_name}" ORDER BY _id DESC LIMIT 100`
+      `SELECT * FROM "${d.table_name}" ORDER BY rowid DESC LIMIT 100`
     ).all();
   }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -319,6 +319,7 @@ export function initializeSchema(db: Database.Database) {
   const runCheck = db.prepare(`SELECT sql FROM sqlite_master WHERE name = 'runs'`).get() as any;
   if (runCheck?.sql && !runCheck.sql.includes("pending")) {
     db.exec(`
+      DROP TABLE IF EXISTS runs_new;
       CREATE TABLE runs_new (
         id TEXT PRIMARY KEY,
         job_id TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
@@ -351,6 +352,7 @@ export function initializeSchema(db: Database.Database) {
   const runCheck2 = db.prepare(`SELECT sql FROM sqlite_master WHERE name = 'runs'`).get() as any;
   if (runCheck2?.sql && !runCheck2.sql.includes("scheduled")) {
     db.exec(`
+      DROP TABLE IF EXISTS runs_new;
       CREATE TABLE runs_new (
         id TEXT PRIMARY KEY,
         job_id TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
@@ -376,6 +378,7 @@ export function initializeSchema(db: Database.Database) {
   const runCheck3 = db.prepare(`SELECT sql FROM sqlite_master WHERE name = 'runs'`).get() as any;
   if (runCheck3?.sql && !runCheck3.sql.includes("killed")) {
     db.exec(`
+      DROP TABLE IF EXISTS runs_new;
       CREATE TABLE runs_new (
         id TEXT PRIMARY KEY,
         job_id TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

Two bugs that surfaced together when schema migrations were interrupted mid-run (e.g. a restart while a table-rebuild migration was in progress):

- **Orphaned `runs_new` blocks all future migrations**: Each migration block that rebuilds the `runs` table via `CREATE TABLE runs_new` now includes `DROP TABLE IF EXISTS runs_new` first. Without this, an interrupted migration leaves an orphaned `runs_new` table that causes every subsequent `initializeSchema()` call to throw on startup — aborting all downstream migrations and leaving the `runs` table missing columns (`kill_requested_at`, `extra_instructions`, `session_id`, `session_cwd`). Every API endpoint touching those columns returns 500 until the DB is repaired manually.

- **`ORDER BY _id DESC` crashes on pre-v1.9 agent-managed tables**: `getRows()` (`database.ts`) and `buildRunPayload()` (`runs.ts`) both sorted linked databases by `_id DESC`. Tables created before v1.9 use `id TEXT PRIMARY KEY` and have no `_id` column. The `SqliteError` from `buildRunPayload()` is especially bad because it fires *after* the run is already claimed (status set to `running` atomically), so the `/next` polling endpoint returns 500 while the run stays stuck in `running` permanently. Fixed by switching to `rowid DESC`, which works for both old (`id TEXT`) and new (`_id INTEGER PRIMARY KEY AUTOINCREMENT`) table generations.

## Test plan

- [ ] Fresh install: verify schema migrations complete cleanly on first start
- [ ] Simulate interrupted migration: manually create a `runs_new` table in the DB, restart the service — verify startup completes without error and the `runs` table has all expected columns
- [ ] Agent with a linked database created before v1.9: verify `/next` returns the run payload without error and the run progresses normally
- [ ] Agent with a linked database created in v1.9+: verify rows still sort correctly (most recent first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)