### PR TITLE
feat: render agent-uploaded attachments in run detail view

### DIFF
--- a/src/app/(app)/runs/[id]/page.tsx
+++ b/src/app/(app)/runs/[id]/page.tsx
@@ -645,6 +645,21 @@ export default function RunDetailPage() {
         </div>
       </div>
 
+      {/* Agent-uploaded attachments (no activity_id) */}
+      {(() => {
+        const orphaned = (run.attachments ?? []).filter(a => a.activity_id === null);
+        if (!orphaned.length) return null;
+        return (
+          <div className="space-y-1">
+            <SectionHeader>Attachments</SectionHeader>
+            <AttachmentList items={orphaned} />
+            {orphaned.filter(a => isVideoAttachment(a)).map(a => (
+              <VideoProcessingInfo key={`proc-${a.id}`} runId={id} attachment={a} />
+            ))}
+          </div>
+        );
+      })()}
+
       {/* Reply Form (waiting, pending, done, failed — but not running) */}
       {(run.status !== "running" && run.status !== "scheduled" && run.status !== "skipped") && (
         <form


### PR DESCRIPTION
Closes #17

## Problem

Attachments uploaded by agents via `POST /api/runs/:id/attachments` have no `activity_id` — they're linked to the run but not to any specific activity entry. The existing activity feed filter (`a.activity_id === entry.id`) skips them entirely, so they were invisible in the dashboard.

## Solution

Added a dedicated **Attachments** section below the activity feed that displays all attachments with `activity_id === null`. Reuses existing `AttachmentList` and `AttachmentDisplay` components, so:
- Images render inline (click to open full-size)
- Non-images render as downloadable chips with filename + size
- Video attachments show the existing processing/transcript controls

The section only appears when there are orphaned attachments, so it stays out of the way for runs that don't use the attachments API.