### PR TITLE
fix(db): repair v1.13.0 jobs/runs migrations (positional INSERT, missing DROP guards, FK orphans)

### DIFF
--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -489,6 +489,7 @@ export function initializeSchema(db: Database.Database) {
     .find((c: any) => c.name === "agent_id");
   if (jobAgentCol?.notnull === 1) {
     db.exec(`
+      DROP TABLE IF EXISTS jobs_new;
       CREATE TABLE jobs_new (
         id TEXT PRIMARY KEY,
         agent_id TEXT REFERENCES agents(id) ON DELETE CASCADE,
@@ -508,7 +509,15 @@ export function initializeSchema(db: Database.Database) {
         thinking TEXT,
         workflow_only INTEGER NOT NULL DEFAULT 0
       );
-      INSERT INTO jobs_new SELECT * FROM jobs;
+      INSERT INTO jobs_new
+        (id, agent_id, name, description, instructions, schedule, workflow_command,
+         active, last_run_at, next_run_at, created_at, updated_at,
+         one_off, timeout_minutes, model, thinking, workflow_only)
+      SELECT
+         id, agent_id, name, description, instructions, schedule, workflow_command,
+         active, last_run_at, next_run_at, created_at, updated_at,
+         one_off, timeout_minutes, model, thinking, workflow_only
+      FROM jobs;
       DROP TABLE jobs;
       ALTER TABLE jobs_new RENAME TO jobs;
       CREATE INDEX IF NOT EXISTS idx_jobs_agent ON jobs(agent_id);
@@ -521,6 +530,9 @@ export function initializeSchema(db: Database.Database) {
     .find((c: any) => c.name === "agent_id");
   if (runAgentCol?.notnull === 1) {
     db.exec(`
+      DELETE FROM runs WHERE job_id NOT IN (SELECT id FROM jobs);
+      DELETE FROM job_env_vars WHERE job_id NOT IN (SELECT id FROM jobs);
+      DROP TABLE IF EXISTS runs_new;
       CREATE TABLE runs_new (
         id TEXT PRIMARY KEY,
         job_id TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
@@ -536,7 +548,13 @@ export function initializeSchema(db: Database.Database) {
         session_id TEXT,
         session_cwd TEXT
       );
-      INSERT INTO runs_new SELECT * FROM runs;
+      INSERT INTO runs_new
+        (id, job_id, agent_id, status, scheduled_for, claimed_at, completed_at,
+         kill_requested_at, created_at, updated_at, extra_instructions, session_id, session_cwd)
+      SELECT
+         id, job_id, agent_id, status, scheduled_for, claimed_at, completed_at,
+         kill_requested_at, created_at, updated_at, extra_instructions, session_id, session_cwd
+      FROM runs;
       DROP TABLE runs;
       ALTER TABLE runs_new RENAME TO runs;
       CREATE INDEX IF NOT EXISTS idx_runs_job ON runs(job_id);


### PR DESCRIPTION
## Summary
The two table-rebuild migrations introduced in v1.13.0 (making `agent_id` nullable on `jobs` and `runs`, `src/lib/db/schema.ts` ~L487–L546) had three latent defects that made upgrades from <= v1.12 crash on every boot.

Fixes #21.

### 1. Positional `INSERT … SELECT *` scrambled columns

```sql
INSERT INTO jobs_new SELECT * FROM jobs;
INSERT INTO runs_new SELECT * FROM runs;
```
`SELECT *` is positional, but the new tables declared columns in a different order than the live tables. For `jobs`, source column 12 `next_run_at` (nullable) maps to destination column 12 `updated_at` (NOT NULL) — every job without a scheduled next run crashes:

```
SqliteError: NOT NULL constraint failed: jobs_new.updated_at
    code: 'SQLITE_CONSTRAINT_NOTNULL'
```

The runs rebuild hits the same pattern (`extra_instructions` → `created_at`) once the jobs crash is past. Even when types line up, this silently corrupts data. The v1.9.2 rebuild migrations in the same file already do this correctly with explicit column lists.

Fixed by listing columns explicitly on both sides of the INSERT for both tables.

### 2. Missing `DROP TABLE IF EXISTS` guard

After the crash, the partial `jobs_new` / `runs_new` table survived. The next boot re-entered the same `if` block and `CREATE TABLE jobs_new` failed because it already existed — the service could never self-recover. Matches the v1.9.2 migrations (L323, L356, L382) which already guard this way. Added `DROP TABLE IF EXISTS *_new;` at the top of each block.

### 3. Orphan FK rows block the runs rebuild

With `PRAGMA foreign_keys=OFF` (better-sqlite3 default), historical deletions left orphan rows in `runs` / `job_env_vars` whose `job_id` no longer existed. With FKs re-enabled during the rebuild, `INSERT INTO runs_new` failed FK validation:

```
SqliteError: FOREIGN KEY constraint failed
    code: 'SQLITE_CONSTRAINT_FOREIGNKEY'
```

On one reproduction this was 14/14 runs and 102 `job_env_vars` rows. Added an orphan cleanup before the runs rebuild — the migration is already doing surgery, so it's a natural place to fix the invalid data.

## Test plan
- [x] Existing vitest suite still passes (82/82)
- [x] Manual repro: upgrade from pre-v1.13 install with orphan rows now boots cleanly; prior to fix it crashed on every boot.