### PR TITLE
fix(runs): allow a job's next scheduled run while a prior run is waiting

### DIFF
--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -895,3 +895,98 @@ describe("Run List Queries", () => {
     expect((recent[0] as any).job_active).toBe(1);
   });
 });
+
+// ===========================================================================
+// Waiting runs should not block scheduling
+// ===========================================================================
+
+describe("Waiting runs do not block new scheduled runs", () => {
+  let agentId: string;
+
+  beforeEach(() => {
+    agentId = seedAgent().id;
+  });
+
+  it("should schedule a new run for the same job when a previous run is waiting", () => {
+    const job = createJob(agentId, { name: "Recurring", schedule: '{"every":60}' });
+    const past = Math.floor(Date.now() / 1000) - 60;
+
+    // Seed a prior run in 'waiting' (e.g. paused for human review)
+    const prior = createRun(job!.id, agentId);
+    updateRunStatus(prior!.id, "waiting");
+
+    // Simulate the scheduler reaching the next fire time
+    updateJob(job!.id, { nextRunAt: past });
+
+    const payload = getAgentNextRun(agentId);
+    expect(payload).not.toBeNull();
+    expect(payload!.job.name).toBe("Recurring");
+    expect(payload!.run.status).toBe("running");
+  });
+
+  it("peek should report available when a job is due and a prior run is waiting", () => {
+    const job = createJob(agentId, { name: "Peekable", schedule: '{"every":60}' });
+    const prior = createRun(job!.id, agentId);
+    updateRunStatus(prior!.id, "waiting");
+    updateJob(job!.id, { nextRunAt: Math.floor(Date.now() / 1000) - 60 });
+
+    const peeked = peekAgentNext(agentId);
+    expect(peeked.available).toBe(true);
+    expect(peeked.job_name).toBe("Peekable");
+  });
+
+  it("should still pick up pending before new scheduled (waiting → pending → resumed)", () => {
+    const job = createJob(agentId, { name: "Resumable", schedule: '{"every":60}' });
+    const run = createRun(job!.id, agentId);
+    updateRunStatus(run!.id, "waiting");
+    updateRunStatus(run!.id, "pending");
+    updateJob(job!.id, { nextRunAt: Math.floor(Date.now() / 1000) - 60 });
+
+    const payload = getAgentNextRun(agentId);
+    expect(payload).not.toBeNull();
+    expect(payload!.run.id).toBe(run!.id);
+    expect(payload!.run.status).toBe("running");
+  });
+
+  it("running on job A DOES block a new scheduled tick on job A (concurrency guard)", () => {
+    const job = createJob(agentId, { name: "Busy", schedule: '{"every":60}' });
+    // Seed a currently-running run
+    createRun(job!.id, agentId);
+    // Force job's next_run_at into the past
+    updateJob(job!.id, { nextRunAt: Math.floor(Date.now() / 1000) - 60 });
+
+    // Agent-level busy check returns null even before the job-level NOT EXISTS runs
+    expect(getAgentNextRun(agentId)).toBeNull();
+
+    // No second run should exist for this job
+    const runs = listRunsByJob(job!.id);
+    expect(runs).toHaveLength(1);
+    expect((runs[0] as any).status).toBe("running");
+  });
+
+  it("pending on job A also blocks a new scheduled tick (waiting-to-resume)", () => {
+    const job = createJob(agentId, { name: "Resuming", schedule: '{"every":60}' });
+    const run = createRun(job!.id, agentId);
+    updateRunStatus(run!.id, "waiting");
+    updateRunStatus(run!.id, "pending");
+    updateJob(job!.id, { nextRunAt: Math.floor(Date.now() / 1000) - 60 });
+
+    // getAgentNextRun should resume the existing pending run, not create a new one
+    const payload = getAgentNextRun(agentId);
+    expect(payload).not.toBeNull();
+    expect(payload!.run.id).toBe(run!.id);
+    expect(listRunsByJob(job!.id)).toHaveLength(1);
+  });
+
+  it("waiting on job A does not block job B on same agent", () => {
+    const jobA = createJob(agentId, { name: "Job A", schedule: '{"every":60}' });
+    const jobB = createJob(agentId, { name: "Job B", schedule: '{"every":60}' });
+    const priorA = createRun(jobA!.id, agentId);
+    updateRunStatus(priorA!.id, "waiting");
+    updateJob(jobB!.id, { nextRunAt: Math.floor(Date.now() / 1000) - 60 });
+
+    const payload = getAgentNextRun(agentId);
+    expect(payload).not.toBeNull();
+    expect(payload!.job.name).toBe("Job B");
+  });
+});

--- a/src/lib/db/runs.ts
+++ b/src/lib/db/runs.ts
@@ -302,7 +302,7 @@ export function getAgentNextRun(agentId: string) {
       WHERE j.agent_id = ? AND j.active = 1 AND j.one_off = 0
       AND j.next_run_at IS NOT NULL AND j.next_run_at <= ?
       AND NOT EXISTS (
-        SELECT 1 FROM runs WHERE job_id = j.id AND status IN ('scheduled', 'running', 'waiting', 'pending')
+        SELECT 1 FROM runs WHERE job_id = j.id AND status IN ('scheduled', 'running', 'pending')
       )
       ORDER BY j.next_run_at ASC LIMIT 1
     `).get(agentId, now) as any;
@@ -364,7 +364,7 @@ export function getNextWorkflowRun() {
       AND j.workflow_only = 1 AND j.workflow_command IS NOT NULL
       AND j.next_run_at IS NOT NULL AND j.next_run_at <= ?
       AND NOT EXISTS (
-        SELECT 1 FROM runs WHERE job_id = j.id AND status IN ('scheduled', 'running', 'waiting', 'pending')
+        SELECT 1 FROM runs WHERE job_id = j.id AND status IN ('scheduled', 'running', 'pending')
       )
       ORDER BY j.next_run_at ASC LIMIT 1
     `).get(now) as any;
@@ -423,7 +423,7 @@ export function peekAgentNext(agentId: string) {
     SELECT j.id, j.name FROM jobs j
     WHERE j.agent_id = ? AND j.active = 1 AND j.one_off = 0
     AND j.next_run_at IS NOT NULL AND j.next_run_at <= ?
-    AND NOT EXISTS (SELECT 1 FROM runs WHERE job_id = j.id AND status IN ('scheduled', 'running', 'waiting', 'pending'))
+    AND NOT EXISTS (SELECT 1 FROM runs WHERE job_id = j.id AND status IN ('scheduled', 'running', 'pending'))
     ORDER BY j.next_run_at ASC LIMIT 1
   `).get(agentId, now) as any;
 


### PR DESCRIPTION
## Summary
`getAgentNextRun`, `getNextWorkflowRun`, and `peekAgentNext` in `src/lib/db/runs.ts` all excluded any job that had a run in status `('scheduled', 'running', 'waiting', 'pending')`. Because `'waiting'` was in that list, once a run was paused awaiting human input, the job's next cron tick was silently dropped — the scheduler treated the waiting run as if it were still occupying the slot, so the due tick was skipped and `next_run_at` advanced past it on the next pass.

This PR removes `'waiting'` from the exclusion list in all three queries.

## Why this is safe (concurrency invariants preserved)
- `'running'` and `'pending'` are still in the exclusion, so an actively executing or resume-pending run still blocks a new scheduled tick on the same job.
- The agent-level running check at `src/lib/db/runs.ts:267-270` (`SELECT id FROM runs WHERE agent_id = ? AND status = 'running'`) still prevents two runs from executing concurrently on the same agent.
- Pending keeps priority over scheduled in the claim order — now locked in by a new test.

## Tests
Added six regression tests in `src/__tests__/db.test.ts` under a new `describe("Waiting runs do not block new scheduled runs")` block:

1. **should schedule a new run for the same job when a previous run is waiting** — *failed before fix, passes after*
2. **peek should report available when a job is due and a prior run is waiting** — *failed before fix, passes after*
3. **should still pick up pending before new scheduled (waiting → pending → resumed)** — locks in pending-over-scheduled priority
4. **running on job A DOES block a new scheduled tick on job A (concurrency guard)** — locks in the no-double-run invariant
5. **pending on job A also blocks a new scheduled tick** — locks in the waiting-to-resume path
6. **waiting on job A does not block job B on same agent** — verifies the fix doesn't over-apply

All 88 tests pass (82 existing + 6 new).

## Test plan
- [x] Vitest suite: 88/88 pass
- [x] Verified by TDD — wrote the two scenario tests first (they failed on `main`), then applied the one-word exclusion change, then re-ran (they pass)