### PR TITLE
fix(runner): surface linked tables in the agent work prompt

### DIFF
--- a/bin/lib/runner.mjs
+++ b/bin/lib/runner.mjs
@@ -226,7 +226,7 @@ function renderAttachmentList(atts, indent = "") {
   return lines.join("\n");
 }
 
-function buildPrompt(payload, apiKey, isResume) {
+export function buildPrompt(payload, apiKey, isResume) {
   const apiPrompt = payload.api ? buildApiPrompt(payload.api, apiKey) : "";
   const allAttachments = Array.isArray(payload.attachments) ? payload.attachments : [];
   // Group attachments by the activity entry they were linked to, so we can
@@ -293,6 +293,19 @@ function buildPrompt(payload, apiKey, isResume) {
     for (const doc of payload.docs) {
       prompt += `### ${doc.title}\n\n${doc.content || "(empty)"}\n\n`;
     }
+  }
+
+  // Tables attached to this job. Each is a read/write reference — only its id is
+  // given (no rows/columns inlined). The agent reads rows via `read_rows` and
+  // writes via `insert_rows`/update/delete, all targeted by the table id (see the
+  // API section). Without this block the agent has no way to learn its table ids:
+  // the list endpoint is org-scoped and rejects the run's exec token.
+  if (payload.tables && Object.keys(payload.tables).length > 0) {
+    prompt += `## Tables\n\nStructured SQLite tables attached to this job, keyed by name. Use the \`id\` shown here to read rows (\`read_rows\`: GET \`.../api/tables/<id>/rows\`) and write them (\`insert_rows\`: POST, plus PUT/DELETE \`.../rows/<_id>\`) — see the Harbour API section for the full URLs and auth. Don't open the database file directly.\n\n`;
+    for (const [name, info] of Object.entries(payload.tables)) {
+      prompt += `- \`${name}\` — id: \`${info?.id ?? ""}\`\n`;
+    }
+    prompt += "\n";
   }
 
   const activity = payload.run.activity || [];

--- a/src/__tests__/runner-finalize.test.ts
+++ b/src/__tests__/runner-finalize.test.ts
@@ -3,6 +3,7 @@ import { getProvider } from "../../bin/lib/providers.mjs";
 import {
   buildApiPrompt,
   buildFinalizePrompt,
+  buildPrompt,
   FINALIZE_MAX_ATTEMPTS,
   finalizeStep,
   isTerminalStatus,
@@ -55,6 +56,39 @@ describe("buildApiPrompt (work prompt)", () => {
   it("keeps the API key and guide url", () => {
     expect(prompt).toContain(API_KEY);
     expect(prompt).toContain("https://h.test/api/guide");
+  });
+});
+
+// ===========================================================================
+// Work prompt: linked tables must be surfaced so the agent can learn their ids.
+// The claim payload carries `tables` (keyed by name, id only); the list endpoint
+// is org-scoped and rejects the run's exec token, so the prompt is the agent's
+// only source of table ids. Regression guard for the dropped `## Tables` block.
+// ===========================================================================
+
+describe("buildPrompt (work prompt) — tables block", () => {
+  const base = {
+    run: { id: "r1", status: "running", title: null, activity: [] },
+    job: { name: "Demo", instructions: "do the thing" },
+    api: API,
+  };
+
+  it("renders a ## Tables section with each linked table's name and id", () => {
+    const prompt = buildPrompt(
+      { ...base, tables: { ad_plans: { id: "tbl-abc" }, support_state: { id: "tbl-def" } } },
+      API_KEY,
+      false,
+    );
+    expect(prompt).toContain("## Tables");
+    expect(prompt).toContain("`ad_plans`");
+    expect(prompt).toContain("tbl-abc");
+    expect(prompt).toContain("`support_state`");
+    expect(prompt).toContain("tbl-def");
+  });
+
+  it("omits the Tables section when the run has no linked tables", () => {
+    expect(buildPrompt({ ...base, tables: {} }, API_KEY, false)).not.toContain("## Tables");
+    expect(buildPrompt(base, API_KEY, false)).not.toContain("## Tables");
   });
 });
 


### PR DESCRIPTION
## What

`buildPrompt` (the runner's agent work-prompt builder) renders the job, reference docs, activity log, attachments, and env var names — but it dropped the claim payload's `tables` block entirely, so an agent never learns the ids of the tables linked to its job.

The table-list endpoint (`GET /api/tables`) is `withOrgAuth` and rejects a run's exec token, so the work prompt is the agent's **only** source of table ids. Without them an agent can't call `read_rows`/`insert_rows` against its linked tables — e.g. it can't mark a support conversation seen, so a dedupe watermark never advances and the backlog gets reprocessed.

## Fix

Render a `## Tables` section listing each linked table's name and id when the run has any (id only — rows are read on demand via `read_rows`/`insert_rows`, per the v2 table contract), mirroring the existing docs/env sections. The resume prompt is intentionally unchanged: the agent already saw its tables on the initial turn.

`buildPrompt` is exported (matching `buildApiPrompt`/`buildFinalizePrompt`) and covered by a regression test in `runner-finalize.test.ts`.

## Verified

- `npx vitest run` — full suite green (incl. 2 new cases for the tables block)
- `tsc --noEmit` clean, `biome check` clean
- Confirmed end-to-end on a live dev install: with the section present, an agent (exec token) reads + writes its linked table via the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
